### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "echo hello word"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # Othello
 A text-based version of the board game Othello made in Python. 
 DISCLAIMER: This was originally written in Python 3.0 and may not be compatible with later versions.
+[![Run on Repl.it](https://repl.it/badge/github/daydreamjesse/Othello)](https://repl.it/github/daydreamjesse/Othello)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@daydreamjesse/Othello).